### PR TITLE
Fix a bug in the RGB-to-grayscale conversion

### DIFF
--- a/core/grayscale.go
+++ b/core/grayscale.go
@@ -6,7 +6,7 @@ import (
 
 // RgbToGrayscale converts the image to grayscale mode.
 func RgbToGrayscale(src *image.NRGBA) []uint8 {
-	rows, cols := src.Bounds().Dx(), src.Bounds().Dy()
+	cols, rows := src.Bounds().Dx(), src.Bounds().Dy()
 	gray := make([]uint8, rows*cols)
 
 	for r := 0; r < rows; r++ {


### PR DESCRIPTION
I noticed and fixed the following typo during a code review of the Pigo code base:

    --- a/core/grayscale.go
    +++ b/core/grayscale.go
    @@ -6,7 +6,7 @@ import (
     
     // RgbToGrayscale converts the image to grayscale mode.
     func RgbToGrayscale(src *image.NRGBA) []uint8 {
    -       rows, cols := src.Bounds().Dx(), src.Bounds().Dy()
    +       cols, rows := src.Bounds().Dx(), src.Bounds().Dy()

This doesn't result in a memory fault since the image array bounds are not exceeded even with the axes swapped around, but it does mean that the grayscale conversion is scrambling the image, which probably has implications for detection quality on non-equilateral images.

For reference, the other locations in the code base that use `src.Bounds()` look to be correct:

    $ git grep src.Bounds
    README.md:cols, rows := src.Bounds().Max.X, src.Bounds().Max.Y
    cmd/pigo/main.go:       cols, rows := src.Bounds().Max.X, src.Bounds().Max.Y
    examples/web/main.go:           cols, rows := src.Bounds().Max.X, src.Bounds().Max.Y
    vendor/github.com/fogleman/gg/util.go:  dst := image.NewRGBA(src.Bounds())
