### PR TITLE
Changed RgbToGrayscale to accept an image.Image interface.

### DIFF
--- a/core/grayscale.go
+++ b/core/grayscale.go
@@ -5,16 +5,17 @@ import (
 )
 
 // RgbToGrayscale converts the image to grayscale mode.
-func RgbToGrayscale(src *image.NRGBA) []uint8 {
+func RgbToGrayscale(src image.Image) []uint8 {
 	cols, rows := src.Bounds().Dx(), src.Bounds().Dy()
 	gray := make([]uint8, rows*cols)
 
-	for r := 0; r < rows; r++ {
-		for c := 0; c < cols; c++ {
-			gray[r*cols+c] = uint8(
-				0.299*float64(src.Pix[r*4*cols+4*c+0]) +
-				0.587*float64(src.Pix[r*4*cols+4*c+1]) +
-				0.114*float64(src.Pix[r*4*cols+4*c+2]),
+	for y := 0; y < rows; y++ {
+		for x := 0; x < cols; x++ {
+			r, g, b, _ := src.At(x, y).RGBA()
+			gray[y*cols+x] = uint8(
+				(0.299*float64(r) +
+					0.587*float64(g) +
+					0.114*float64(b)) / 256,
 			)
 		}
 	}


### PR DESCRIPTION
This is a really nice library! I have been using it on a Raspberry Pi for real-time processing and I think the proposed pull request gives better performance.

Accepting the interface `image.Image` makes this function easier to use with `gocv.NewMat().ToImage()` and other fuctions that might implement `image.Image`.  It skips the use of `pigo.ImgToNRGBA(img)`, which gives a performance boost when doing real-time analysis.