### PR TITLE
Added a note about imports when using the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ dets := classifier.RunCascade(cParams, angle)
 dets = classifier.ClusterDetections(dets, 0.2)
 ```
 
+**A note about imports**:  in order to decode the image you will need to import `image/jpeg` or `image/png` (depending on the provided image type) and the Pigo library as well, otherwise you will get a `"Image: Unkown format"` error. See the following example:
+```Go
+import (
+    _ "image/jpeg"
+    pigo "github.com/esimov/pigo/core"
+)
+```
+If you don't do this you will get a "Image: Unkown format" error
+
 ## Usage
 A command line utility is bundled into the library to detect faces in static images.
 


### PR DESCRIPTION
I noticed that when decoding I would always get an Unkown Format error and that was because I had to import the image/jpeg library. I made a little note in the readme so others won't fall down this rabbit hole.

Thanks!

Also thanks for creating this project, it's a real life saver :smile: 